### PR TITLE
Session management

### DIFF
--- a/src/client/application/application.go
+++ b/src/client/application/application.go
@@ -1,10 +1,10 @@
 package application
 
 import (
-	"github.com/pkg/errors"
+	"sync"
+	"time"
 
 	"myst/pkg/logger"
-	"myst/src/client/application/domain/credentials"
 	"myst/src/client/application/domain/entry"
 	"myst/src/client/application/domain/invitation"
 	"myst/src/client/application/domain/keystore"
@@ -13,120 +13,60 @@ import (
 
 var log = logger.New("app", logger.Blue)
 
-// Enclave is the repository that handles storing and retrieving of the
-// user's keystores and credentials. It requires initialization and
-// authentication before it can be used. The authentication status can
-// expire after some time if the HealthCheck method is not called
-// regularly.
-type Enclave interface {
-	Initialize(password string) error
-	IsInitialized() (bool, error)
-	Authenticate(password string) error
-	HealthCheck()
-
-	CreateKeystore(k keystore.Keystore) (keystore.Keystore, error)
-	Keystore(id string) (keystore.Keystore, error)
-	UpdateKeystore(k keystore.Keystore) (keystore.Keystore, error)
-	Keystores() (map[string]keystore.Keystore, error)
-	DeleteKeystore(id string) error
-
-	UpdateCredentials(creds credentials.Credentials) (credentials.Credentials, error)
-	Credentials() (credentials.Credentials, error)
-}
-
-// Remote is a remote repository that holds upstream enclave/invitations. It is
-// used to sync keystores with a remote server in a secure manner, and to
-// facilitate inviting users to access keystores or accepting invitations to
-// access a keystore from another user. Authenticating with a username and
-// password is required to interface with a remote.
-type Remote interface {
-	Address() string
-
-	CreateKeystore(k keystore.Keystore) (keystore.Keystore, error)
-	UpdateKeystore(k keystore.Keystore) (keystore.Keystore, error)
-	Keystores(privateKey []byte) (map[string]keystore.Keystore, error)
-	DeleteKeystore(id string) error
-
-	CreateInvitation(keystoreRemoteId, inviteeUsername string) (invitation.Invitation, error)
-	Invitation(id string) (invitation.Invitation, error)
-	AcceptInvitation(id string) (invitation.Invitation, error)
-	DeleteInvitation(id string) (invitation.Invitation, error)
-	FinalizeInvitation(invitationId string, privateKey, inviteePublicKey []byte, k keystore.Keystore) (invitation.Invitation, error)
-	Invitations() (map[string]invitation.Invitation, error)
-
-	Authenticate(username, password string) error
-	Register(username, password string, publicKey []byte) (user.User, error)
-	Authenticated() bool
-	CurrentUser() *user.User
-
-	SharedSecret(privateKey []byte, userId string) ([]byte, error)
-}
-
-var (
-	ErrKeystoreNotFound       = errors.New("keystore not found")
-	ErrAuthenticationRequired = errors.New("authentication required")
-	ErrAuthenticationFailed   = errors.New("authentication failed")
-	ErrInitializationRequired = errors.New("initialization required")
-	ErrInvalidPassword        = errors.New("invalid password")
-	ErrInvalidWebsite         = errors.New("invalid website")
-	ErrorInvalidUsername      = errors.New("invalid username")
-	ErrEntryNotFound          = errors.New("entry not found")
-	ErrInvalidKeystoreName    = errors.New("invalid keystore name")
-	ErrCredentialsNotFound    = errors.New("credentials not found")
-	ErrEnclaveExists          = errors.New("enclave already exists")
-	ErrInvitationNotFound     = errors.New("invitation not found")
-	ErrForbidden              = errors.New("forbidden")
-	ErrSharedSecretNotFound   = errors.New("shared secret not found")
-	ErrRemoteAddressMismatch  = errors.New("remote address mismatch")
-)
-
 type UpdateEntryOptions struct {
 	Password *string
 	Notes    *string
 }
 
 type Application interface {
-	Initialize(password string) error
-	IsInitialized() (bool, error)
-	Authenticate(password string) error
-	HealthCheck()
+	Initialize(password string) (sessionId []byte, err error)
+	IsInitialized(sessionId []byte) (bool, error)
+	Authenticate(password string) (sessionId []byte, err error)
+	HealthCheck(sessionId []byte) error
 
-	CreateKeystore(name string) (keystore.Keystore, error)
-	DeleteKeystore(id string) error
-	Keystore(id string) (keystore.Keystore, error)
-	Keystores() (map[string]keystore.Keystore, error)
+	CreateKeystore(sessionId []byte, name string) (keystore.Keystore, error)
+	DeleteKeystore(sessionId []byte, id string) error
+	Keystore(sessionId []byte, id string) (keystore.Keystore, error)
+	Keystores(sessionId []byte) (map[string]keystore.Keystore, error)
 
-	CreateEntry(keystoreId string, website, username, password, notes string) (entry.Entry, error)
-	UpdateEntry(keystoreId string, entryId string, opts UpdateEntryOptions) (entry.Entry, error)
-	DeleteEntry(keystoreId, entryId string) error
+	CreateEntry(sessionId []byte, keystoreId string, website, username, password, notes string) (entry.Entry, error)
+	UpdateEntry(sessionId []byte, keystoreId string, entryId string, opts UpdateEntryOptions) (entry.Entry, error)
+	DeleteEntry(sessionId []byte, keystoreId, entryId string) error
 
-	Register(username, password string) (user.User, error)
-	CurrentUser() (*user.User, error)
-	SharedSecret(userId string) ([]byte, error)
+	Register(sessionId []byte, username, password string) (user.User, error)
+	CurrentUser(sessionId []byte) (*user.User, error)
+	SharedSecret(sessionId []byte, userId string) ([]byte, error)
 
-	CreateInvitation(keystoreId string, inviteeUsername string) (invitation.Invitation, error)
-	AcceptInvitation(id string) (invitation.Invitation, error)
-	DeleteInvitation(id string) (invitation.Invitation, error)
-	FinalizeInvitation(invitationId, remoteKeystoreId string, inviteePublicKey []byte) (invitation.Invitation, error)
-	Invitations() (map[string]invitation.Invitation, error)
-	Invitation(id string) (invitation.Invitation, error)
+	CreateInvitation(sessionId []byte, keystoreId string, inviteeUsername string) (invitation.Invitation, error)
+	AcceptInvitation(sessionId []byte, id string) (invitation.Invitation, error)
+	DeleteInvitation(sessionId []byte, id string) (invitation.Invitation, error)
+	FinalizeInvitation(sessionId []byte, invitationId, remoteKeystoreId string, inviteePublicKey []byte) (invitation.Invitation, error)
+	Invitations(sessionId []byte) (map[string]invitation.Invitation, error)
+	Invitation(sessionId []byte, id string) (invitation.Invitation, error)
 
 	Sync() error
 }
 
 type application struct {
-	enclave Enclave
-	remote  Remote
+	enclave  Enclave
+	remote   Remote
+	sessions map[string]time.Time
+	key      []byte
+	mux      sync.Mutex
 }
 
 func New(opts ...Option) Application {
-	app := &application{}
+	app := &application{
+		sessions: make(map[string]time.Time),
+	}
 
 	for _, opt := range opts {
 		if opt != nil {
 			opt(app)
 		}
 	}
+
+	go app.startHealthCheck()
 
 	return app
 }

--- a/src/client/application/errors.go
+++ b/src/client/application/errors.go
@@ -1,0 +1,21 @@
+package application
+
+import "github.com/pkg/errors"
+
+var (
+	ErrKeystoreNotFound       = errors.New("keystore not found")
+	ErrAuthenticationRequired = errors.New("authentication required")
+	ErrAuthenticationFailed   = errors.New("authentication failed")
+	ErrInitializationRequired = errors.New("initialization required")
+	ErrInvalidPassword        = errors.New("invalid password")
+	ErrInvalidWebsite         = errors.New("invalid website")
+	ErrorInvalidUsername      = errors.New("invalid username")
+	ErrEntryNotFound          = errors.New("entry not found")
+	ErrInvalidKeystoreName    = errors.New("invalid keystore name")
+	ErrCredentialsNotFound    = errors.New("credentials not found")
+	ErrEnclaveExists          = errors.New("enclave already exists")
+	ErrInvitationNotFound     = errors.New("invitation not found")
+	ErrForbidden              = errors.New("forbidden")
+	ErrSharedSecretNotFound   = errors.New("shared secret not found")
+	ErrRemoteAddressMismatch  = errors.New("remote address mismatch")
+)

--- a/src/client/application/interfaces.go
+++ b/src/client/application/interfaces.go
@@ -1,0 +1,56 @@
+package application
+
+import (
+	"myst/src/client/application/domain/credentials"
+	"myst/src/client/application/domain/invitation"
+	"myst/src/client/application/domain/keystore"
+	"myst/src/client/application/domain/user"
+)
+
+// Enclave is the repository that handles storing and retrieving of the
+// user's keystores and credentials. It requires initialization and
+// authentication before it can be used. The authentication status can
+// expire after some time if the HealthCheck method is not called
+// regularly.
+type Enclave interface {
+	Initialize(password string) (key []byte, err error)
+	IsInitialized() (bool, error)
+	Authenticate(password string) (key []byte, err error)
+
+	CreateKeystore(key []byte, k keystore.Keystore) (keystore.Keystore, error)
+	Keystore(key []byte, id string) (keystore.Keystore, error)
+	UpdateKeystore(key []byte, k keystore.Keystore) (keystore.Keystore, error)
+	Keystores(key []byte) (map[string]keystore.Keystore, error)
+	DeleteKeystore(key []byte, id string) error
+
+	UpdateCredentials(key []byte, creds credentials.Credentials) (credentials.Credentials, error)
+	Credentials(key []byte) (credentials.Credentials, error)
+}
+
+// Remote is a remote repository that holds upstream enclave/invitations. It is
+// used to sync keystores with a remote server in a secure manner, and to
+// facilitate inviting users to access keystores or accepting invitations to
+// access a keystore from another user. Authenticating with a username and
+// password is required to interface with a remote.
+type Remote interface {
+	Address() string
+
+	CreateKeystore(k keystore.Keystore) (keystore.Keystore, error)
+	UpdateKeystore(k keystore.Keystore) (keystore.Keystore, error)
+	Keystores(privateKey []byte) (map[string]keystore.Keystore, error)
+	DeleteKeystore(id string) error
+
+	CreateInvitation(keystoreRemoteId, inviteeUsername string) (invitation.Invitation, error)
+	Invitation(id string) (invitation.Invitation, error)
+	AcceptInvitation(id string) (invitation.Invitation, error)
+	DeleteInvitation(id string) (invitation.Invitation, error)
+	FinalizeInvitation(invitationId string, privateKey, inviteePublicKey []byte, k keystore.Keystore) (invitation.Invitation, error)
+	Invitations() (map[string]invitation.Invitation, error)
+
+	Authenticate(username, password string) error
+	Register(username, password string, publicKey []byte) (user.User, error)
+	Authenticated() bool
+	CurrentUser() *user.User
+
+	SharedSecret(privateKey []byte, userId string) ([]byte, error)
+}

--- a/src/client/application/session.go
+++ b/src/client/application/session.go
@@ -1,0 +1,54 @@
+package application
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"myst/pkg/rand"
+)
+
+func (app *application) newSession() (sessionId []byte, err error) {
+	// check is active are by the same user of the enclave.
+	sessionKey, err := rand.Bytes(16)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to generate session key")
+	}
+
+	app.sessions[string(sessionKey)] = time.Now()
+
+	return sessionKey, nil
+}
+
+func (app *application) sessionActive(sessionId []byte) bool {
+	if sessionId == nil {
+		return false
+	}
+	_, ok := app.sessions[string(sessionId)]
+	return ok
+}
+
+func (app *application) startHealthCheck() {
+	ticker := time.NewTicker(20 * time.Second) // FIXME @rdnt: make this configurable
+	defer ticker.Stop()
+
+	for range ticker.C {
+		app.mux.Lock()
+
+		for sessionId, lastHealthCheck := range app.sessions {
+			elapsed := time.Since(lastHealthCheck)
+
+			if elapsed < time.Minute {
+				continue
+			}
+
+			delete(app.sessions, sessionId)
+
+			if len(app.sessions) == 0 && app.key != nil {
+				app.key = nil
+			}
+		}
+
+		app.mux.Unlock()
+	}
+}

--- a/src/client/enclaverepo/repository_test.go
+++ b/src/client/enclaverepo/repository_test.go
@@ -18,16 +18,18 @@ func TestRepository(t *testing.T) {
 	pass, err := rand.String(16)
 	assert.NilError(t, err)
 
-	err = repo.Initialize(pass)
+	key, err := repo.Initialize(pass)
 	assert.NilError(t, err)
 
-	err = repo.Authenticate(pass)
+	key2, err := repo.Authenticate(pass)
 	assert.NilError(t, err)
 
-	k, err := repo.CreateKeystore(keystore.New(keystore.WithName("test")))
+	assert.DeepEqual(t, key, key2)
+
+	k, err := repo.CreateKeystore(key, keystore.New(keystore.WithName("test")))
 	assert.NilError(t, err)
 
-	k2, err := repo.Keystore(k.Id)
+	k2, err := repo.Keystore(key, k.Id)
 	assert.NilError(t, err)
 
 	assert.Equal(t, k.Id, k2.Id)

--- a/src/client/rest/convert.go
+++ b/src/client/rest/convert.go
@@ -9,13 +9,13 @@ import (
 	"myst/src/client/rest/generated"
 )
 
-func (s *Server) invitationToJSON(inv invitation.Invitation) (generated.Invitation, error) {
-	inviter, err := s.userToJSON(inv.Inviter)
+func (s *Server) invitationToJSON(sessionId []byte, inv invitation.Invitation) (generated.Invitation, error) {
+	inviter, err := s.userToJSON(sessionId, inv.Inviter)
 	if err != nil {
 		return generated.Invitation{}, err
 	}
 
-	invitee, err := s.userToJSON(inv.Invitee)
+	invitee, err := s.userToJSON(sessionId, inv.Invitee)
 	if err != nil {
 		return generated.Invitation{}, err
 	}
@@ -38,10 +38,10 @@ func (s *Server) invitationToJSON(inv invitation.Invitation) (generated.Invitati
 	}, nil
 }
 
-func (s *Server) userToJSON(u user.User) (generated.User, error) {
+func (s *Server) userToJSON(sessionId []byte, u user.User) (generated.User, error) {
 	var icon *string
 
-	sharedSecret, err := s.app.SharedSecret(u.Id)
+	sharedSecret, err := s.app.SharedSecret(sessionId, u.Id)
 	if err != nil {
 		return generated.User{}, err
 	}

--- a/src/client/rest/generated/client.gen.go
+++ b/src/client/rest/generated/client.gen.go
@@ -1427,6 +1427,7 @@ func (r RegisterResponse) StatusCode() int {
 type AuthenticateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON200      *SessionId
 	JSONDefault  *Error
 }
 
@@ -1471,6 +1472,7 @@ func (r EnclaveResponse) StatusCode() int {
 type CreateEnclaveResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON201      *SessionId
 	JSONDefault  *Error
 }
 
@@ -2156,6 +2158,13 @@ func ParseAuthenticateResponse(rsp *http.Response) (*AuthenticateResponse, error
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SessionId
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -2208,6 +2217,13 @@ func ParseCreateEnclaveResponse(rsp *http.Response) (*CreateEnclaveResponse, err
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest SessionId
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/src/client/rest/generated/models.gen.go
+++ b/src/client/rest/generated/models.gen.go
@@ -116,6 +116,9 @@ type RegisterRequest struct {
 	Username string `json:"username"`
 }
 
+// SessionId defines model for SessionId.
+type SessionId = string
+
 // UpdateEntryRequest defines model for UpdateEntryRequest.
 type UpdateEntryRequest struct {
 	Notes    *string `json:"notes,omitempty"`

--- a/src/client/rest/import.go
+++ b/src/client/rest/import.go
@@ -10,6 +10,7 @@ import (
 )
 
 func (s *Server) DebugImport(c *gin.Context) {
+	sid := sessionId(c)
 	keystoreName := "Passwords"
 	b := []byte("")
 
@@ -22,7 +23,7 @@ func (s *Server) DebugImport(c *gin.Context) {
 		return
 	}
 
-	k, err := s.app.CreateKeystore(keystoreName)
+	k, err := s.app.CreateKeystore(sid, keystoreName)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
@@ -40,6 +41,7 @@ func (s *Server) DebugImport(c *gin.Context) {
 		password := row[3]
 
 		_, err := s.app.CreateEntry(
+			sid,
 			k.Id,
 			website,
 			username,

--- a/src/client/rest/invitation.go
+++ b/src/client/rest/invitation.go
@@ -11,7 +11,9 @@ import (
 )
 
 func (s *Server) GetInvitations(c *gin.Context) {
-	invs, err := s.app.Invitations()
+	sid := sessionId(c)
+
+	invs, err := s.app.Invitations(sid)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
@@ -20,7 +22,7 @@ func (s *Server) GetInvitations(c *gin.Context) {
 
 	restInvs := generated.Invitations{}
 	for _, inv := range invs {
-		restInv, err := s.invitationToJSON(inv)
+		restInv, err := s.invitationToJSON(sid, inv)
 		if err != nil {
 			log.Error(err)
 			Error(c, http.StatusInternalServerError)
@@ -34,6 +36,7 @@ func (s *Server) GetInvitations(c *gin.Context) {
 }
 
 func (s *Server) CreateInvitation(c *gin.Context) {
+	sid := sessionId(c)
 	keystoreId := c.Param("keystoreId")
 
 	var req generated.CreateInvitationRequest
@@ -44,14 +47,14 @@ func (s *Server) CreateInvitation(c *gin.Context) {
 		return
 	}
 
-	inv, err := s.app.CreateInvitation(keystoreId, req.Invitee)
+	inv, err := s.app.CreateInvitation(sid, keystoreId, req.Invitee)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
 		return
 	}
 
-	restInv, err := s.invitationToJSON(inv)
+	restInv, err := s.invitationToJSON(sid, inv)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
@@ -62,9 +65,10 @@ func (s *Server) CreateInvitation(c *gin.Context) {
 }
 
 func (s *Server) AcceptInvitation(c *gin.Context) {
+	sid := sessionId(c)
 	invitationId := c.Param("invitationId")
 
-	inv, err := s.app.AcceptInvitation(invitationId)
+	inv, err := s.app.AcceptInvitation(sid, invitationId)
 	if errors.Is(err, application.ErrInvitationNotFound) {
 		Error(c, http.StatusNotFound)
 		return
@@ -77,7 +81,7 @@ func (s *Server) AcceptInvitation(c *gin.Context) {
 		return
 	}
 
-	restInv, err := s.invitationToJSON(inv)
+	restInv, err := s.invitationToJSON(sid, inv)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
@@ -88,16 +92,17 @@ func (s *Server) AcceptInvitation(c *gin.Context) {
 }
 
 func (s *Server) DeclineOrCancelInvitation(c *gin.Context) {
+	sid := sessionId(c)
 	invitationId := c.Param("invitationId")
 
-	inv, err := s.app.DeleteInvitation(invitationId)
+	inv, err := s.app.DeleteInvitation(sid, invitationId)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
 		return
 	}
 
-	restInv, err := s.invitationToJSON(inv)
+	restInv, err := s.invitationToJSON(sid, inv)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
@@ -108,9 +113,10 @@ func (s *Server) DeclineOrCancelInvitation(c *gin.Context) {
 }
 
 func (s *Server) GetInvitation(c *gin.Context) {
+	sid := sessionId(c)
 	invitationId := c.Param("invitationId")
 
-	inv, err := s.app.Invitation(invitationId)
+	inv, err := s.app.Invitation(sid, invitationId)
 	if errors.Is(err, application.ErrInvitationNotFound) {
 		Error(c, http.StatusNotFound)
 		return
@@ -120,7 +126,7 @@ func (s *Server) GetInvitation(c *gin.Context) {
 		return
 	}
 
-	restInv, err := s.invitationToJSON(inv)
+	restInv, err := s.invitationToJSON(sid, inv)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
@@ -131,6 +137,7 @@ func (s *Server) GetInvitation(c *gin.Context) {
 }
 
 func (s *Server) FinalizeInvitation(c *gin.Context) {
+	sid := sessionId(c)
 	invitationId := c.Param("invitationId")
 
 	var req generated.FinalizeInvitationRequest
@@ -140,14 +147,14 @@ func (s *Server) FinalizeInvitation(c *gin.Context) {
 		return
 	}
 
-	inv, err := s.app.FinalizeInvitation(invitationId, req.RemoteKeystoreId, req.InviteePublicKey)
+	inv, err := s.app.FinalizeInvitation(sid, invitationId, req.RemoteKeystoreId, req.InviteePublicKey)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
 		return
 	}
 
-	restInv, err := s.invitationToJSON(inv)
+	restInv, err := s.invitationToJSON(sid, inv)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)

--- a/src/client/rest/openapi.json
+++ b/src/client/rest/openapi.json
@@ -49,7 +49,14 @@
         },
         "responses": {
           "201": {
-            "description": "Enclave created"
+            "description": "authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionId"
+                }
+              }
+            }
           },
           "default": {
             "description": "Error",
@@ -99,7 +106,14 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "authentication token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionId"
+                }
+              }
+            }
           },
           "default": {
             "description": "Error",
@@ -1002,6 +1016,9 @@
           "id",
           "token"
         ]
+      },
+      "SessionId": {
+        "type": "string"
       },
       "Error": {
         "type": "object",

--- a/src/client/rest/user.go
+++ b/src/client/rest/user.go
@@ -9,6 +9,8 @@ import (
 )
 
 func (s *Server) Register(c *gin.Context) {
+	sid := sessionId(c)
+
 	var req generated.RegisterRequest
 	err := c.ShouldBindJSON(&req)
 	if err != nil {
@@ -16,14 +18,14 @@ func (s *Server) Register(c *gin.Context) {
 		return
 	}
 
-	u, err := s.app.Register(req.Username, req.Password)
+	u, err := s.app.Register(sid, req.Username, req.Password)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)
 		return
 	}
 
-	restUser, err := s.userToJSON(u)
+	restUser, err := s.userToJSON(sid, u)
 	if err != nil {
 		log.Error(err)
 		Error(c, http.StatusInternalServerError)

--- a/src/server/application/application.go
+++ b/src/server/application/application.go
@@ -40,7 +40,7 @@ var (
 	ErrKeystoreNotFound     = errors.New("keystore not found")
 	ErrInvalidUsername      = errors.New("invalid username")
 	ErrInvalidPassword      = errors.New("invalid password")
-	ErrAuthenticationFailed = errors.New("authorization failed")
+	ErrAuthenticationFailed = errors.New("authentication failed")
 	ErrInvalidInvitee       = errors.New("invalid inviter")
 	ErrInviterNotFound      = errors.New("inviter not found")
 	ErrInviteeNotFound      = errors.New("invitee not found")

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -11,13 +11,13 @@ import (
 func TestAuthorization(t *testing.T) {
 	s := suite.New(t)
 
-	err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	sessionId, err := s.Client1.App.Initialize(s.Client1.MasterPassword)
 	assert.NilError(t, err)
 
-	_, err = s.Client1.App.Register(s.Client1.Username, s.Client1.Password)
+	_, err = s.Client1.App.Register(sessionId, s.Client1.Username, s.Client1.Password)
 	assert.NilError(t, err)
 
-	u, err := s.Client1.App.CurrentUser()
+	u, err := s.Client1.App.CurrentUser(sessionId)
 	assert.NilError(t, err)
 	assert.Equal(t, u.Username, s.Client1.Username)
 

--- a/test/integration/invitation_test.go
+++ b/test/integration/invitation_test.go
@@ -13,22 +13,25 @@ import (
 func TestInvitations(t *testing.T) {
 	s := suite.New(t)
 
-	err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	sessionId, err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	assert.NilError(t, err)
+	s.Client1.SessionId = sessionId
+
+	_, err = s.Client1.App.Register(sessionId, s.Client1.Username, s.Client1.Password)
 	assert.NilError(t, err)
 
-	_, err = s.Client1.App.Register(s.Client1.Username, s.Client1.Password)
+	session2Id, err := s.Client2.App.Initialize(s.Client2.MasterPassword)
+	assert.NilError(t, err)
+	s.Client2.SessionId = session2Id
+
+	_, err = s.Client2.App.Register(session2Id, s.Client2.Username, s.Client2.Password)
 	assert.NilError(t, err)
 
-	err = s.Client2.App.Initialize(s.Client2.MasterPassword)
+	session3Id, err := s.Client3.App.Initialize(s.Client3.MasterPassword)
 	assert.NilError(t, err)
+	s.Client3.SessionId = session3Id
 
-	_, err = s.Client2.App.Register(s.Client2.Username, s.Client2.Password)
-	assert.NilError(t, err)
-
-	err = s.Client3.App.Initialize(s.Client3.MasterPassword)
-	assert.NilError(t, err)
-
-	_, err = s.Client3.App.Register(s.Client3.Username, s.Client3.Password)
+	_, err = s.Client3.App.Register(session3Id, s.Client3.Username, s.Client3.Password)
 	assert.NilError(t, err)
 
 	keystore := s.CreateKeystore(t)
@@ -91,16 +94,18 @@ func TestInvitations(t *testing.T) {
 func TestInvitationDelete(t *testing.T) {
 	s := suite.New(t)
 
-	err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	s1id, err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	assert.NilError(t, err)
+	s.Client1.SessionId = s1id
+
+	_, err = s.Client1.App.Register(s1id, s.Client1.Username, s.Client1.Password)
 	assert.NilError(t, err)
 
-	_, err = s.Client1.App.Register(s.Client1.Username, s.Client1.Password)
+	s2id, err := s.Client2.App.Initialize(s.Client2.MasterPassword)
 	assert.NilError(t, err)
+	s.Client2.SessionId = s2id
 
-	err = s.Client2.App.Initialize(s.Client2.MasterPassword)
-	assert.NilError(t, err)
-
-	_, err = s.Client2.App.Register(s.Client2.Username, s.Client2.Password)
+	_, err = s.Client2.App.Register(s2id, s.Client2.Username, s.Client2.Password)
 	assert.NilError(t, err)
 
 	keystore := s.CreateKeystore(t)
@@ -133,16 +138,18 @@ func TestInvitationDelete(t *testing.T) {
 func TestInvitationDecline(t *testing.T) {
 	s := suite.New(t)
 
-	err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	s1id, err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	assert.NilError(t, err)
+	s.Client1.SessionId = s1id
+
+	_, err = s.Client1.App.Register(s1id, s.Client1.Username, s.Client1.Password)
 	assert.NilError(t, err)
 
-	_, err = s.Client1.App.Register(s.Client1.Username, s.Client1.Password)
+	s2id, err := s.Client2.App.Initialize(s.Client2.MasterPassword)
 	assert.NilError(t, err)
+	s.Client2.SessionId = s2id
 
-	err = s.Client2.App.Initialize(s.Client2.MasterPassword)
-	assert.NilError(t, err)
-
-	_, err = s.Client2.App.Register(s.Client2.Username, s.Client2.Password)
+	_, err = s.Client2.App.Register(s2id, s.Client2.Username, s.Client2.Password)
 	assert.NilError(t, err)
 
 	keystore := s.CreateKeystore(t)
@@ -173,16 +180,18 @@ func TestInvitationDecline(t *testing.T) {
 func TestInvitationAccept(t *testing.T) {
 	s := suite.New(t)
 
-	err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	s1id, err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	assert.NilError(t, err)
+	s.Client1.SessionId = s1id
+
+	_, err = s.Client1.App.Register(s1id, s.Client1.Username, s.Client1.Password)
 	assert.NilError(t, err)
 
-	_, err = s.Client1.App.Register(s.Client1.Username, s.Client1.Password)
+	s2id, err := s.Client2.App.Initialize(s.Client2.MasterPassword)
 	assert.NilError(t, err)
+	s.Client2.SessionId = s2id
 
-	err = s.Client2.App.Initialize(s.Client2.MasterPassword)
-	assert.NilError(t, err)
-
-	_, err = s.Client2.App.Register(s.Client2.Username, s.Client2.Password)
+	_, err = s.Client2.App.Register(s2id, s.Client2.Username, s.Client2.Password)
 	assert.NilError(t, err)
 
 	keystore := s.CreateKeystore(t)
@@ -244,16 +253,18 @@ func TestInvitationAccept(t *testing.T) {
 func TestInvitationFinalize(t *testing.T) {
 	s := suite.New(t)
 
-	err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	s1id, err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	assert.NilError(t, err)
+	s.Client1.SessionId = s1id
+
+	_, err = s.Client1.App.Register(s1id, s.Client1.Username, s.Client1.Password)
 	assert.NilError(t, err)
 
-	_, err = s.Client1.App.Register(s.Client1.Username, s.Client1.Password)
+	s2id, err := s.Client2.App.Initialize(s.Client2.MasterPassword)
 	assert.NilError(t, err)
+	s.Client2.SessionId = s2id
 
-	err = s.Client2.App.Initialize(s.Client2.MasterPassword)
-	assert.NilError(t, err)
-
-	_, err = s.Client2.App.Register(s.Client2.Username, s.Client2.Password)
+	_, err = s.Client2.App.Register(s2id, s.Client2.Username, s.Client2.Password)
 	assert.NilError(t, err)
 
 	keystore := s.CreateKeystore(t)

--- a/test/integration/keystore_test.go
+++ b/test/integration/keystore_test.go
@@ -14,8 +14,9 @@ import (
 func TestKeystores(t *testing.T) {
 	s := suite.New(t)
 
-	err := s.Client1.App.Initialize(s.Client1.MasterPassword)
+	s1id, err := s.Client1.App.Initialize(s.Client1.MasterPassword)
 	assert.NilError(t, err)
+	s.Client1.SessionId = s1id
 
 	t.Run("keystoresWithKeys are empty", func(t *testing.T) {
 		res, err := s.Client1.Client.KeystoresWithResponse(s.Ctx)

--- a/ui/src/api/generated/index.ts
+++ b/ui/src/api/generated/index.ts
@@ -22,6 +22,7 @@ export type { Keystore } from './models/Keystore';
 export type { Keystores } from './models/Keystores';
 export type { LoginRequest } from './models/LoginRequest';
 export type { RegisterRequest } from './models/RegisterRequest';
+export type { SessionId } from './models/SessionId';
 export type { UnlockKeystoreRequest } from './models/UnlockKeystoreRequest';
 export type { UpdateEntryRequest } from './models/UpdateEntryRequest';
 export type { User } from './models/User';

--- a/ui/src/api/generated/models/SessionId.ts
+++ b/ui/src/api/generated/models/SessionId.ts
@@ -1,0 +1,5 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type SessionId = string;

--- a/ui/src/api/generated/services/DefaultService.ts
+++ b/ui/src/api/generated/services/DefaultService.ts
@@ -15,6 +15,7 @@ import type { Keystore } from '../models/Keystore';
 import type { Keystores } from '../models/Keystores';
 import type { LoginRequest } from '../models/LoginRequest';
 import type { RegisterRequest } from '../models/RegisterRequest';
+import type { SessionId } from '../models/SessionId';
 import type { UpdateEntryRequest } from '../models/UpdateEntryRequest';
 import type { User } from '../models/User';
 
@@ -39,14 +40,14 @@ export class DefaultService {
     /**
      * Sets up the myst enclave with a master password
      * @returns Error Error
-     * @returns any Enclave created
+     * @returns SessionId authentication token
      * @throws ApiError
      */
     public static createEnclave({
 requestBody,
 }: {
 requestBody: CreateEnclaveRequest,
-}): CancelablePromise<Error | any> {
+}): CancelablePromise<Error | SessionId> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/enclave',
@@ -70,7 +71,7 @@ requestBody: CreateEnclaveRequest,
 
     /**
      * Attempts to authenticate the user
-     * @returns any OK
+     * @returns SessionId authentication token
      * @returns Error Error
      * @throws ApiError
      */
@@ -78,7 +79,7 @@ requestBody: CreateEnclaveRequest,
 requestBody,
 }: {
 requestBody: AuthenticateRequest,
-}): CancelablePromise<any | Error> {
+}): CancelablePromise<SessionId | Error> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/authenticate',

--- a/ui/src/components/LoginForm.svelte
+++ b/ui/src/components/LoginForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import api from "@/api";
+  import api, {OpenAPI} from "@/api";
+  import type {SessionId} from "@/api";
   import InputField from "@/components/InputField.svelte";
   import {createEventDispatcher} from 'svelte';
   import PasswordInputField from "@/components/PasswordInputField.svelte";
@@ -11,16 +12,17 @@
 
   let error: boolean = false;
 
-  function submit() {
+  const submit = async () => {
     if (!passwordValid) {
       return;
     }
 
-    api.authenticate({
+    await api.authenticate({
       requestBody: {
         password
       }
-    }).then(() => {
+    }).then((resp: SessionId) => {
+      OpenAPI.TOKEN = resp
       dispatch('login')
       password = ''
     }).catch((err) => {


### PR DESCRIPTION
This PR adds session identifiers that should be used by the user of the application (e.g. separate HTTP REST clients, or a CLI client) to authenticate against the application. Sessions will have a time to live that resets using the HealthCheck method. If no sessions are present the argon key is purged from in-memory.

This adds proper security locally in case some program installed does queries against the application while the user is authenticated, which previously would return all the decrypted data.